### PR TITLE
Rearranging documents to have a canonical reference for the rules

### DIFF
--- a/active-working-group-rules.md
+++ b/active-working-group-rules.md
@@ -1,0 +1,90 @@
+ENS Working Group Rules
+-----------------------
+
+*This document represents the current state of the Working Group Rules as of 2024, as created originally by EP4, replaced by EP1.8 (formerly EP12) and then amended by EP4.7. These should represent the canonical version of the rules and any social proposal to amend it should include a PR to this document.*
+
+
+### Working Groups Rules
+
+#### 1. Formation of Working Groups
+   1. To create a new working group, a social proposal, as defined by the ENS governance documentation (‘Social Proposal’), must be put forward and passed by the DAO.
+   2. A Social Proposal to create a new working group must demonstrate that the new working group is needed and the work cannot be undertaken within an existing working group.
+#### 2. Dissolution of Working Groups
+   1. A working group can be dissolved by passing a Social Proposal requesting the dissolution of a working group or working groups.
+   2. If an active proposal is put forward to dissolve a working group, all working group funds, including outgoing payments, within that working group, are to be frozen with immediate effect, pending the outcome of that vote.
+   3. Upon the dissolution of a working group, any and all unspent working group funds from that working group, at the time of dissolution, must be immediately returned to the DAO treasury, without delay.
+#### 3. Working Group Stewards
+   1. Each working group shall be managed by three stewards (hereafter a ‘Steward’ or ‘Stewards’).
+   2. Stewards will be elected to serve within working groups for a set period of one calendar year (hereafter known as a ‘Term’).
+   3. The Term for Stewards commences at 9am UTC on January 1 each year and ends immediately prior to the commencement of the Term of the following year.
+   4. Stewards are responsible for overseeing the operation of working groups in accordance with these rules and the ENS DAO constitution.
+   5. The responsibilities of Stewards include, but are not limited to:
+      1. Requesting working group funds from the DAO in accordance with these rules;
+      2. Approving the creation of sub-groups or workstreams within a working group to undertake work and/or carry out specific projects or tasks;
+      3. Dissolving sub-groups or workstreams within a working group;
+      4. Using discretion to make working group funds available to sub-groups, workstreams, or contributors within a working group;
+      5. Using discretion to disburse working group funds to people and/or projects in accordance with the ENS DAO constitution; and
+      6. Acting as keyholders of working group multi-sigs.
+#### 4. Steward Eligibility and Nominations
+   1. Any individual is eligible to nominate themselves to be a Steward of a working group within the DAO (‘Eligible Person’).
+   2. To be eligible for the election for the annual Term, Eligible Persons must nominate themselves between 9am UTC on December 6 and 9am UTC on December 9 (‘Nomination Window’).
+   3. An Eligible Person may nominate themselves to become a Steward of a working group during the Nomination Window, by meeting the requirements set out in a call for nominations posted in the relevant working group category of the ENS governance forum.
+   4. An Eligible Person who completes the steps outlined in rule 4.3 above during the Nomination Window and receives 10,000 signed votes to support their nomination will be included in the ballot as a nominee in the election for Stewards that takes place following that Nomination Window (‘Nominee’).
+#### 5. Steward Elections
+   1. Elections for working group Stewards for the upcoming year will take place by a vote of governance token holders using signed messages and will be open for 120 hours, commencing at 9am UTC on December 10 each year (‘Election Window’).
+   2. The top-ranked Nominees from the working group vote held during the Election Window will fill any available positions for the role of Steward for those working groups for the upcoming Term, based on the order in which they are ranked in the vote.
+   3. A Nominee elected to serve as a Steward may not take up the role of Steward for more than two working groups during their Term.
+#### 6. Delay of Nominations or Elections
+   1. In the event that nominations or elections for Stewards take place after a Nomination Window or after an Election Window, the nomination process and/or elections shall take place, as otherwise prescribed in rules 4 and 5 above, as soon as is practicable after the missed Nomination Window or missed Election Window.
+   2. In the event that an election takes place outside of an Election Window and after the commencement date of a new Term, outgoing Stewards from the previous Term shall stay in their positions as working group Stewards until immediately prior to 9am UTC the day following the end of the election, which, for the avoidance of doubt, is 120 hours after voting in those elections commenced.
+   3. In the event that an election takes place outside of an Election Window and after the commencement date of a new Term, newly elected Stewards will assume the responsibilities of stewardship within working groups at 9am UTC the day following the end of the election, as defined in rule 6.2 above, for the remainder of that Term.
+#### 7. Removal and Replacement of Stewards
+   1. Stewards may be removed at any time by:
+      1. a Social Proposal passed by the DAO; or
+      2. a simple indicative majority vote among Stewards of all working groups, with the outcome of that vote communicated in the relevant working group category of the ENS governance forum.
+   2. Stewards may step down from their position at any time by communicating their intention to step down in the ENS governance forum.
+   3. In the event that a Steward is removed, steps down, or is unable to continue as a Steward, for whatever reason, prior to the end of a Term, a new election must be held to fill any vacant Steward positions, in accordance with rule 6 above.
+#### 8. Lead Stewards
+   1. Each working group must appoint a lead Steward within the first five days of a Term (hereafter a 'Lead Steward' or 'Lead Stewards').
+   2. Only current elected Stewards of a working group are eligible to serve as Lead Stewards within a given working group.
+   3. Lead Stewards may be appointed or removed from that role at any time by a simple indicative majority vote among the Stewards of a working group, with the outcome of that vote communicated in the relevant working group category of the ENS governance forum.
+   4. In the event that a Lead Steward steps down from the position or is removed as a Lead Steward before the end of a Term in accordance with rule 8.3 above, a new Lead Steward must be appointed within five calendar days.
+   5. A Steward who is appointed to serve as a Lead Steward of a working group will remain in that position, as Lead Steward, from the date of appointment until the end of their elected Term as a Steward or until they are removed as a Lead Steward in accordance with rule 8.3 above or until they are removed as a Steward in accordance with rule 7 above.
+   6. Lead Stewards are responsible for the operational management and administration of working groups and are expected to provide regular updates to the DAO in the ENS governance forum related to working group progress, achievements, and challenges.
+   7. The responsibilities of Lead Stewards include, but are not limited to:
+      1. Acting as a representative of a working group;
+      2. Managing resource requests from sub-groups, workstreams, and contributors within a working group;
+      3. Initiating the disbursement of working group funds on an as-needed basis;
+      4. Providing reports of working group spending in the ENS governance forum; and
+      5. Maintaining open communications with DAO participants in the ENS governance forum.
+#### 9. DAO Secretary
+   1. At the start of each Term, the current Stewards of each working group shall collaborate to appoint an individual who will serve as the secretary of the DAO (hereafter 'Secretary' or 'Secretaries').
+   2. The Secretary may be appointed or removed from that role at any time by a majority vote of all elected Stewards in a given Term with the outcome of that vote communicated in the ENS governance forum.
+   3. The Secretary will remain in that position, as Secretary of the DAO, from the date of appointment until the end of a given Term or until the date at which they are removed from that position in accordance with rule 9.2 above.
+   4. Secretaries are eligible to receive fair compensation for their work as Secretary of the DAO.
+   5. Compensation for the Secretary of the DAO is to be paid by the Meta-Governance Working Group using funds requested in accordance with rule 10 below.
+   6. Any individual is eligible to be appointed as the Secretary of the DAO, including past and present working group Stewards.
+   7. The Secretary is responsible for managing working relationships and communications across working groups as well as performing administrative duties for the DAO.
+   8. The responsibilities of the Secretary include, but are not limited to:
+      1. Managing a DAO-wide calendar;
+      2. Coordinating and attending working group meetings where possible and ensuring meeting summaries are posted in the ENS governance forum;
+      3. Assisting Stewards with coordination challenges within working groups; and
+      4. Acting as a multi-sig keyholder for each working group.
+#### 10. Working Group Funds
+  1. To request working group funds, Stewards of all working groups will collaborate to submit an active executable proposal, as defined by the ENS governance documentation ('Collective Proposal'), to the DAO during the months of January, April, July, and October each calendar year (each a ‘Funding Window’).
+       1. In order for a working group to have a funding request included in a Collective Proposal submitted to the DAO during a Funding Window, the funding request must have passed as a Social Proposal in the same Funding Window.
+       2. In the case of an emergency, where working group funds are needed by a working group outside of a Funding Window, an executable proposal, as defined by the ENS governance documentation, may be submitted at any time by a Steward of a working group to request funds from the DAO.
+  2. Working group funds requested and approved in accordance with rule 10.1 above are to be paid out into separate working group multi-sigs controlled by the DAO.
+  3. Each working group multi-sig must have four keyholders, made up of three current elected Stewards for that working group and the Secretary of the DAO for that Term, with no other keyholders permitted.
+  4. Working group funds may be disbursed from working group multi-sigs with three-of-four keyholder signing.
+  5. Stewards of a given working group shall have the discretion to reallocate funds approved in a Collective Proposal where appropriate and where it is not in conflict with any rules of the DAO, DAO bylaws, or the ENS DAO constitution.
+  6. 
+#### 11. Compensation for Stewards and Lead Stewards
+  1. Stewards are eligible to receive fair compensation for their work as a Steward or Lead Steward in the DAO.
+  2. All requests for Steward or Lead Steward compensation must be detailed in a Collective Proposal for working group funds submitted to the DAO in accordance with rule 10.1 above.
+  3. Stewards may not receive compensation for their role as a Steward or Lead Steward outside of that compensation expressly provided for in a Collective Proposal submitted to the DAO in accordance with rule 10.1 above.
+  4. The Meta-Governance working group are responsible for defining standards for fair compensation ('Compensation Guidelines').
+  5. The Compensation Guidelines shall be defined prior to the Nomination Window for each term and can only take effect for the following term.
+
+#### 13. Amendments
+  1. These rules may be amended at any time by passing a Social Proposal.

--- a/stewards.md
+++ b/stewards.md
@@ -1,0 +1,138 @@
+ENS DAO Stewards
+----------------
+
+
+Stewards are roles nominated yearly by the DAO, according to the Working Group Rules. 
+
+
+## Current Term: 2024
+
+### Meta-governance Working Group
+
+**election pending**
+
+
+### Ecosystem Working Group
+
+**election pending**
+
+
+### Punlic Goods Working Group
+
+**election pending**
+
+
+## Past Terms
+
+### 2023 Q3/Q4
+
+#### Meta-Governance Working Group
+
+| ![Nick Johnson / nick.eth](https://metadata.ens.domains/mainnet/avatar/nick.eth) | ![Spence / 5pence.eth](https://metadata.ens.domains/mainnet/avatar/5pence.eth) | ![Katherine Wu / katherineykwu.eth](https://metadata.ens.domains/mainnet/avatar/katherineykwu.eth) |
+| --- | --- | --- |
+| Nick Johnson / nick.eth | Spence / 5pence.eth | Katherine Wu / katherineykwu.eth |
+
+
+#### ENS Ecosystem Working Group
+
+| ![slobo.eth](https://metadata.ens.domains/mainnet/avatar/slobo.eth) | ![limes.eth](https://metadata.ens.domains/mainnet/avatar/limes.eth) | ![184.eth](https://metadata.ens.domains/mainnet/avatar/184.eth) |
+| --- | --- | --- |
+| slobo.eth | limes.eth | 184.eth |
+
+#### Public Goods Working Group
+
+| ![coltron.eth](https://metadata.ens.domains/mainnet/avatar/coltron.eth) | ![Simona / simona.eth](https://metadata.ens.domains/mainnet/avatar/simona.eth) | ![vegayp.eth](https://metadata.ens.domains/mainnet/avatar/vegayp.eth) |
+| --- | --- | --- |
+| coltron.eth | Simona / simona.eth | vegayp.eth |
+
+### 2023 Q1/Q2
+
+#### Meta-Governance Working Group
+
+| ![nick.eth](https://metadata.ens.domains/mainnet/avatar/nick.eth) | ![simona.eth](https://metadata.ens.domains/mainnet/avatar/simona.eth) | ![Katherine Wu](https://metadata.ens.domains/mainnet/avatar/katherineykwu.eth) |
+| --- | --- | --- |
+| nick.eth | simona.eth | Katherine Wu |
+
+#### ENS Ecosystem Working Group
+
+| ![slobo.eth](https://metadata.ens.domains/mainnet/avatar/slobo.eth) | ![limes.eth](https://metadata.ens.domains/mainnet/avatar/limes.eth) | ![yambo.eth](https://metadata.ens.domains/mainnet/avatar/yambo.eth) |
+| --- | --- | --- |
+| slobo.eth | limes.eth | yambo.eth |
+
+#### Public Goods Working Group
+
+| ![avsa.eth](https://metadata.ens.domains/mainnet/avatar/avsa.eth) | ![coltron.eth](https://metadata.ens.domains/mainnet/avatar/coltron.eth) | ![vegayp.eth](https://metadata.ens.domains/mainnet/avatar/vegayp.eth) |
+| --- | --- | --- |
+| avsa.eth | coltron.eth | vegayp.eth |
+
+
+### 2022 Q3/Q4
+
+#### Meta-Governance
+
+| ![coltron.eth](https://metadata.ens.domains/mainnet/avatar/coltron.eth) | ![simona.eth](https://metadata.ens.domains/mainnet/avatar/simona.eth) | ![nick.eth](https://metadata.ens.domains/mainnet/avatar/nick.eth) |
+| --- | --- | --- |
+| coltron.eth | simona.eth | nick.eth |
+
+#### ENS Ecosystem
+
+| ![bobjiang.eth](https://metadata.ens.domains/mainnet/avatar/bobjiang.eth) | ![validator.eth](https://metadata.ens.domains/mainnet/avatar/validator.eth) | ![slobo.eth](https://metadata.ens.domains/mainnet/avatar/slobo.eth) |
+| --- | --- | --- |
+| bobjiang.eth | validator.eth | slobo.eth |
+
+#### Community
+
+| ![limes.eth](https://metadata.ens.domains/mainnet/avatar/limes.eth) | ![coltron.eth](https://metadata.ens.domains/mainnet/avatar/coltron.eth) | ![validator.eth](https://metadata.ens.domains/mainnet/avatar/validator.eth) |
+| --- | --- | --- |
+| limes.eth | coltron.eth | validator.eth |
+
+#### Public Goods
+
+| ![anthonyware.eth](https://metadata.ens.domains/mainnet/avatar/anthonyware.eth) | ![ceresstation.eth](https://metadata.ens.domains/mainnet/avatar/ceresstation.eth) | ![avsa.eth](https://metadata.ens.domains/mainnet/avatar/avsa.eth) |
+| --- | --- | --- |
+| anthonyware.eth | ceresstation.eth | avsa.eth |
+
+
+
+### 2022 Q1/Q2
+### 2022 Q1/Q2
+
+#### Meta-Governance
+
+| ![jmj.eth](https://metadata.ens.domains/mainnet/avatar/jmj.eth) | ![simona.eth](https://metadata.ens.domains/mainnet/avatar/simona.eth) | ![james.eth](https://metadata.ens.domains/mainnet/avatar/james.eth) |
+| --- | --- | --- |
+| jmj.eth | simona.eth | james.eth |
+
+| ![nick.eth](https://metadata.ens.domains/mainnet/avatar/nick.eth) | ![leontalbert.eth](https://metadata.ens.domains/mainnet/avatar/leontalbert.eth) |  |
+| --- | --- | --- |
+| nick.eth | leontalbert.eth |  |
+
+#### ENS Ecosystem
+
+| ![ginge.eth](https://metadata.ens.domains/mainnet/avatar/ginge.eth) | ![slobo.eth](https://metadata.ens.domains/mainnet/avatar/slobo.eth) | ![bobjiang.eth](https://metadata.ens.domains/mainnet/avatar/bobjiang.eth) |
+| --- | --- | --- |
+| ginge.eth | slobo.eth | bobjiang.eth |
+
+| ![nick.eth](https://metadata.ens.domains/mainnet/avatar/nick.eth) | ![jefflau.eth](https://metadata.ens.domains/mainnet/avatar/jefflau.eth) |  |
+| --- | --- | --- |
+| nick.eth | jefflau.eth |  |
+
+#### Community
+
+| ![limes.eth](https://metadata.ens.domains/mainnet/avatar/limes.eth) | ![coltron.eth](https://metadata.ens.domains/mainnet/avatar/coltron.eth) | ![spencecoin.eth](https://metadata.ens.domains/mainnet/avatar/spencecoin.eth) |
+| --- | --- | --- |
+| limes.eth | coltron.eth | spencecoin.eth |
+
+| ![brantly.eth](https://metadata.ens.domains/mainnet/avatar/brantly.eth) | ![validator.eth](https://metadata.ens.domains/mainnet/avatar/validator.eth) |  |
+| --- | --- | --- |
+| brantly.eth | validator.eth |  |
+
+#### Public Goods
+
+| ![sumedha.eth](https://metadata.ens.domains/mainnet/avatar/sumedha.eth) | ![ceresstation.eth](https://metadata.ens.domains/mainnet/avatar/ceresstation.eth) | ![avsa.eth](https://metadata.ens.domains/mainnet/avatar/avsa.eth) |
+| --- | --- | --- |
+| sumedha.eth | ceresstation.eth | avsa.eth |
+
+| ![matoken.eth](https://metadata.ens.domains/mainnet/avatar/matoken.eth) | ![ricmoo.eth](https://metadata.ens.domains/mainnet/avatar/ricmoo.eth) |  |
+| --- | --- | --- |
+| matoken.eth | ricmoo.eth |  |


### PR DESCRIPTION
I thought it would be good if the governance docs also had a canonical "current rules"which would reflect the current state of the rules, for which other amendments could have a PR for. Also it would be useful to have a Stewards page with a fast reference to the current and past stewards.

The page reflects the rules supposing that ep4.7, which ends tomorrow, will pass.