### PR TITLE
Create ep2.x(formerly-ep15)-dissolution-of-the-community-working-grou…

### DIFF
--- a/governance-proposals/term-2/ep2.x(formerly-ep15)-dissolution-of-the-community-working-group.md
+++ b/governance-proposals/term-2/ep2.x(formerly-ep15)-dissolution-of-the-community-working-group.md
@@ -1,0 +1,57 @@
+---
+Summary: >-
+  Dissolve the Community Working Group at the conclusion of the First Term (Q1/Q2) of 2022.
+---
+
+# \[EP15] \[Social] Dissolve Community Working Group
+
+
+
+| **Status**  | Active                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Discussion Thread** | [Discuss](https://discuss.ens.domains/t/draft-social-dissolve-community-working-group/12982) |
+| **Vote**   | [Snapshot](https://snapshot.org/#/ens.eth/proposal/0xa64ec8b446e509cb4b75092c4a714897790b70e2711fc3d6afa969c250e7eb92) - Passed, [Onchain](https://www.tally.xyz/governance/eip155:1:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3/proposal/43203199770691383238593940280239053946984014979449022275641313046078578194694) - Active |
+| **Authors** | [alisha.eth](https://twitter.com/futurealisha)                                                                                                                                                                                                                                                                                                         |
+
+## Description
+
+This was previously numbered EP14, but was renumbered due to a numbering collision.
+
+This is a proposal to dissolve the Community Working Group at the conclusion of the First Term of 2022 in accordance with rule 3.1 of the working group rules passed under EP 4. 
+
+If this proposal is passed, the Community Working Group will be dissolved at the conclusion of the First Term of 2022, leaving three remaining working groups within the ENS DAO:
+
+1. Meta-Governance Working Group;
+2. ENS Ecosystem Working Group; and
+3. Public Goods Working Group.
+
+On the basis that new working groups cannot be formed within the DAO unless it can shown that “… the work cannot be undertaken within an existing working group” (rule 2.2), the same standard should apply for the dissolution of working groups.
+
+After consulting with Stewards and Community Working Group participants, regarding their work and experiences during the First Term of 2022, it is clear that:
+
+1. Each subgroup within the Community Working Group could comfortably fall within the Ecosystem Working Group; and 
+2. The DAO does not have enough active participants to justify having "community" as a standalone working group. 
+
+Therefore, using the same standard set out in rule 2.2, we should dissolve the Community Working Group and migrate all existing subgroups from that working group to the Ecosystem Working Group or another working group as appropriate. 
+
+By dissolving the Community Working Group, the remaining working groups will have distinct mandates that provide clarity for contributors, without overlap. This will allow stewards to more efficiently facilitate work within the remaining working groups.
+
+Please note: there is currently an election taking place on Snapshot to elect Community Working Group Stewards for the Second Term. 
+
+This proposal, to dissolve the Community Working Group, has been moved to a vote at this time at the request of current Meta-Governance Working Group Stewards to minimize disruption and ensure that results are available soon after steward elections conclude. 
+
+If this vote passes, incoming Community Working Group Stewards will not be required to serve as Stewards of the Community Working Group in the Second Term, which starts on July 1, 2022. If the vote does not pass, incoming community stewards will take up their positions within the Community Working Group on July 1, 2022. 
+
+## Specification
+
+This is a proposal to:
+
+1. Dissolve the Community Working Group;
+2. Return any unspent funds remaining in the Community Working Group multi-sig, at end of the First Term of 2022, to the ENS DAO treasury; and
+3. Migrate all existing subgroups within the Community Working Group to other working groups within the ENS DAO before the end of the First Term of 2022.
+
+The ENS DAO will have three working groups for the Second Term of 2022 and all Terms thereafter. These working groups will be:
+
+- Meta-Governance Working Group: provides governance oversight and support of the management and operation of the ENS DAO;
+- ENS Ecosystem Working Group: continues development and improvement of the ENS protocol and ecosystem; and
+- Public Goods Working Group: funds public goods within web3 in accordance with the ENS DAO constitution.


### PR DESCRIPTION
…p.md

EP15 was named EP14 in error under the old naming convention resulting in a conflict and renaming the same to EP 15.  

However, even with the correction to EP15 under the old naming convention the file was erroneously included under term-4 in github.  To illustrate the problem of the old naming convention further, this EP is not include at all on the Governance Documentation located at: https://docs.ens.domains/v/governance/governance-proposals

This PR both moves the file to the proper term-2 on GitHub and renames the same to ep2.x(formerly ep15).  Unfortunately there is no correct enumeration under the revised naming convention; therefore, this is the sole EP/file name proposed with an "x" to fit between 2.1 and 2.2.1.  For purposes of clarity the file has been named "ep2.x(formerly ep15)...".